### PR TITLE
Treat arrays as values rather than merging their contents

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -5,7 +5,8 @@ function mergeProperty(a, b, prop) {
     if (b.hasOwnProperty(prop)) {
       aValue = a[prop];
       bValue = b[prop];
-      if (typeof(aValue) === 'object' && typeof(bValue) === 'object') {
+      if (typeof(aValue) === 'object' && typeof(bValue) === 'object' &&
+        !(Array.isArray(aValue) || Array.isArray(bValue))) {
         a[prop] = merge(aValue, bValue);
       } else {
         a[prop] = bValue;


### PR DESCRIPTION
If my common environment defines _allowedUsers_ as ["John", "Pete"], and my production environment defines _allowedUsers_ as ["John", "Jake"], the final config would be ["John", "Pete", "Jake"] -- with no way to exclude Pete from production.

This change makes it possible to override entire arrays (and consequently remove values) in different environments.
